### PR TITLE
Add branch rules to CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,8 @@ and a React island for the interactive flashcard tool. Hosted on Netlify.
 - Full-screen mode
 - Flagged / starred words system
 - Games or quiz modes
+
+## Branch rules
+Always open pull requests against the development branch, not main.
+Never commit directly to main or development.
+Always create a new feature branch for each task.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,3 +52,8 @@ Never add internal links manually in page files.
 - FAQ sections use FAQ schema markup as JSON-LD
 - Print CSS on every list page
 - Canonical tags on every page
+
+## Branch rules
+Always open pull requests against the development branch, not main.
+Never commit directly to main or development.
+Always create a new feature branch for each task.


### PR DESCRIPTION
Adds the "Branch rules" section to the bottom of both CLAUDE.md and AGENTS.md as requested in issue #7.

Generated with [Claude Code](https://claude.ai/code)