### PR TITLE
feat: Add BaseLayout.astro shared layout component

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,83 @@
+---
+interface Props {
+  title: string;
+  description: string;
+  canonicalUrl: string;
+}
+
+const { title, description, canonicalUrl } = Astro.props;
+const currentYear = new Date().getFullYear();
+
+const navLinks = [
+  { href: "/dolch-sight-words", label: "Dolch Words" },
+  { href: "/fry-sight-words", label: "Fry Words" },
+  { href: "/kindergarten-sight-words", label: "Kindergarten" },
+  { href: "/sight-word-games", label: "Games" },
+  { href: "/sight-words-printable", label: "Printable" },
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalUrl} />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:type" content="website" />
+  </head>
+  <body class="min-h-screen flex flex-col bg-white text-gray-900">
+    <header class="bg-white border-b border-gray-200 sticky top-0 z-10">
+      <nav class="max-w-5xl mx-auto px-4 py-3">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+          <a
+            href="/"
+            class="text-xl font-bold text-blue-700 hover:text-blue-800 shrink-0"
+          >
+            Sight Words
+          </a>
+          <ul class="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+            {
+              navLinks.map(({ href, label }) => (
+                <li>
+                  <a
+                    href={href}
+                    class="text-gray-600 hover:text-blue-700 font-medium"
+                  >
+                    {label}
+                  </a>
+                </li>
+              ))
+            }
+          </ul>
+        </div>
+      </nav>
+    </header>
+
+    <main class="flex-1 max-w-5xl w-full mx-auto px-4 py-6">
+      <slot />
+    </main>
+
+    <footer class="bg-gray-50 border-t border-gray-200 mt-auto">
+      <div class="max-w-5xl mx-auto px-4 py-6 text-sm text-gray-600">
+        <div class="flex flex-wrap gap-x-4 gap-y-1 mb-3">
+          <a href="/dolch-sight-words" class="hover:text-blue-700">Dolch Words</a>
+          <a href="/fry-sight-words" class="hover:text-blue-700">Fry Words</a>
+          <a href="/kindergarten-sight-words" class="hover:text-blue-700">Kindergarten</a>
+          <a href="/sight-word-games" class="hover:text-blue-700">Games</a>
+          <a href="/sight-words-printable" class="hover:text-blue-700">Printable</a>
+        </div>
+        <p class="text-gray-500">Free to use — no sign-up required.</p>
+        <p class="text-gray-400 mt-1">&copy; {currentYear} Sight Words. All rights reserved.</p>
+      </div>
+    </footer>
+
+    <div class="ad-slot"></div>
+  </body>
+</html>


### PR DESCRIPTION
Creates the shared `BaseLayout.astro` layout used by all pages.

Includes full `<head>` with Open Graph tags, sticky header nav, main slot, footer, and ad-slot placeholder.

Closes #9

Generated with [Claude Code](https://claude.ai/code)