### PR TITLE
feat: add core components (WordTable, RelatedPages, FAQ, PrintButton) and print CSS

### DIFF
--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -1,0 +1,39 @@
+---
+interface FAQ {
+  question: string;
+  answer: string;
+}
+
+interface Props {
+  faqs: FAQ[];
+}
+
+const { faqs } = Astro.props;
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": faqs.map((faq) => ({
+    "@type": "Question",
+    "name": faq.question,
+    "acceptedAnswer": {
+      "@type": "Answer",
+      "text": faq.answer,
+    },
+  })),
+};
+---
+
+<section class="mt-10 pt-8 border-t border-gray-200">
+  <h2 class="text-xl font-bold text-gray-800 mb-6">Frequently Asked Questions</h2>
+  <div class="space-y-6">
+    {faqs.map((faq) => (
+      <div>
+        <h3 class="text-base font-semibold text-gray-800 mb-1">{faq.question}</h3>
+        <p class="text-gray-600 leading-relaxed">{faq.answer}</p>
+      </div>
+    ))}
+  </div>
+</section>
+
+<script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />

--- a/src/components/PrintButton.astro
+++ b/src/components/PrintButton.astro
@@ -1,0 +1,9 @@
+---
+---
+
+<button
+  onclick="window.print()"
+  class="no-print inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors text-sm"
+>
+  Print this list
+</button>

--- a/src/components/RelatedPages.astro
+++ b/src/components/RelatedPages.astro
@@ -1,0 +1,29 @@
+---
+import allLists from "../data/words.json";
+
+interface Props {
+  currentSlug: string;
+}
+
+const { currentSlug } = Astro.props;
+
+const relatedLists = allLists.filter((list) => list.slug !== currentSlug);
+---
+
+{relatedLists.length > 0 && (
+  <section class="mt-10 pt-8 border-t border-gray-200">
+    <h2 class="text-xl font-bold text-gray-800 mb-4">More Sight Word Lists</h2>
+    <ul class="flex flex-wrap gap-3">
+      {relatedLists.map((list) => (
+        <li>
+          <a
+            href={`/${list.slug}`}
+            class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+          >
+            {list.name} Sight Words List
+          </a>
+        </li>
+      ))}
+    </ul>
+  </section>
+)}

--- a/src/components/WordTable.astro
+++ b/src/components/WordTable.astro
@@ -1,0 +1,38 @@
+---
+interface Props {
+  words: string[];
+  listName: string;
+}
+
+const { words, listName } = Astro.props;
+
+// Split words into rows of 3 for the table
+const rows: string[][] = [];
+for (let i = 0; i < words.length; i += 3) {
+  rows.push(words.slice(i, i + 3));
+}
+---
+
+<div class="overflow-x-auto">
+  <table class="w-full border-collapse text-left" aria-label={`${listName} word list`}>
+    <thead>
+      <tr class="bg-blue-50">
+        <th class="px-4 py-2 text-sm font-semibold text-blue-800 border border-blue-100 w-1/3">Word</th>
+        <th class="px-4 py-2 text-sm font-semibold text-blue-800 border border-blue-100 w-1/3">Word</th>
+        <th class="px-4 py-2 text-sm font-semibold text-blue-800 border border-blue-100 w-1/3">Word</th>
+      </tr>
+    </thead>
+    <tbody>
+      {rows.map((row, i) => (
+        <tr class={i % 2 === 0 ? "bg-white" : "bg-gray-50"}>
+          {row.map((word) => (
+            <td class="px-4 py-3 text-lg font-medium text-gray-800 border border-gray-100">{word}</td>
+          ))}
+          {row.length < 3 && Array.from({ length: 3 - row.length }).map(() => (
+            <td class="px-4 py-3 border border-gray-100"></td>
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  </table>
+</div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -26,6 +26,21 @@ const navLinks = [
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalUrl} />
 
+    <style>
+@media print {
+  header, footer, .ad-slot, .flashcard-tool, .no-print {
+    display: none;
+  }
+  .word-list {
+    column-count: 3;
+    font-size: 24pt;
+  }
+  body {
+    font-size: 12pt;
+  }
+}
+</style>
+
     <!-- Open Graph -->
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />


### PR DESCRIPTION
Adds four core Astro components and print CSS as requested in issue #11.

- `WordTable.astro`: static HTML word table with 3 columns
- `RelatedPages.astro`: internal links from words.json excluding current page
- `FAQ.astro`: FAQ section with JSON-LD schema markup
- `PrintButton.astro`: print trigger button
- `BaseLayout.astro`: print media CSS added to `<head>`

Closes #11

Generated with [Claude Code](https://claude.ai/code)