### PR TITLE
First content page: homepage + what-are-sight-words

### DIFF
--- a/src/data/words.json
+++ b/src/data/words.json
@@ -11,5 +11,39 @@
       "look", "make", "me", "my", "not", "one", "play", "red", "run", "said",
       "see", "the", "three", "to", "two", "up", "we", "where", "yellow", "you"
     ]
+  },
+  {
+    "name": "Dolch Primer",
+    "grade": "Kindergarten",
+    "slug": "dolch-primer",
+    "wordCount": 52,
+    "description": "The Dolch Primer list contains 52 sight words for kindergarten readers.",
+    "words": [
+      "all", "am", "are", "at", "ate", "be", "black", "brown", "but", "came",
+      "did", "do", "eat", "four", "get", "good", "have", "he", "into", "like",
+      "must", "new", "no", "now", "on", "our", "out", "please", "pretty", "ran",
+      "ride", "saw", "say", "she", "so", "soon", "that", "there", "they", "this",
+      "too", "under", "want", "was", "well", "went", "what", "white", "who", "will",
+      "with", "yes"
+    ]
+  },
+  {
+    "name": "Fry 1-100",
+    "grade": "1st Grade",
+    "slug": "fry-1-100",
+    "wordCount": 100,
+    "description": "The first 100 Fry sight words, ranked by frequency of use in reading materials.",
+    "words": [
+      "the", "of", "and", "a", "to", "in", "is", "you", "that", "it",
+      "he", "was", "for", "on", "are", "as", "with", "his", "they", "I",
+      "at", "be", "this", "have", "from", "or", "one", "had", "by", "word",
+      "but", "not", "what", "all", "were", "we", "when", "your", "can", "said",
+      "there", "use", "an", "each", "which", "she", "do", "how", "their", "if",
+      "will", "up", "other", "about", "out", "many", "then", "them", "these", "so",
+      "some", "her", "would", "make", "like", "him", "into", "time", "has", "look",
+      "two", "more", "write", "go", "see", "number", "no", "way", "could", "people",
+      "my", "than", "first", "water", "been", "call", "who", "oil", "its", "now",
+      "find", "long", "down", "day", "did", "get", "come", "made", "may", "part"
+    ]
   }
 ]

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,3 +1,151 @@
 ---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import Flashcard from "../components/Flashcard.jsx";
+import FAQ from "../components/FAQ.astro";
+import RelatedPages from "../components/RelatedPages.astro";
+import allWords from "../data/words.json";
+
+const dolchPrePrimer = allWords.find((list) => list.slug === "dolch-pre-primer");
+const dolchPrimer = allWords.find((list) => list.slug === "dolch-primer");
+const fry1100 = allWords.find((list) => list.slug === "fry-1-100");
+
+const faqs = [
+  {
+    question: "What are sight words?",
+    answer:
+      "Sight words are common words that children are taught to recognize instantly, without needing to sound them out. They appear so frequently in text that being able to read them automatically helps children read faster and more fluently.",
+  },
+  {
+    question: "What is the difference between Dolch and Fry sight words?",
+    answer:
+      "Dolch words are a list of 220 common words compiled by Edward Dolch in 1948, organized by grade level from pre-primer through 3rd grade. Fry words are a more modern list of 1000 words compiled by Edward Fry, ranked by frequency of use in reading materials.",
+  },
+  {
+    question: "How many sight words should my kindergartner know?",
+    answer:
+      "Most kindergartners are expected to know between 20 and 50 sight words by the end of the school year. The Dolch pre-primer and primer lists are the standard starting point.",
+  },
+  {
+    question: "How do I use these flashcards?",
+    answer:
+      "Tap the speaker icon to hear the word spoken aloud. Use the Next and Previous buttons to move through the list. Tap Shuffle to practice in a random order. You can hold your phone up to your child so they can see the word clearly on the screen.",
+  },
+];
 ---
-<h1>Sight Words — Coming Soon</h1>
+
+<BaseLayout
+  title="Sight Words — Free Flashcards, Lists & Printables"
+  description="Free sight words flashcards, lists, and printables for kindergarten through 2nd grade. Includes Dolch and Fry word lists with audio."
+  canonicalUrl="https://placeholder.com"
+>
+  <h1 class="text-3xl font-bold text-gray-900 mb-4">Sight Words</h1>
+
+  <p class="text-gray-600 leading-relaxed mb-8">
+    Free flashcards, word lists, and printables for every grade level. Practice
+    Dolch and Fry sight words with audio — no sign-up required. Works great on
+    your phone.
+  </p>
+
+  <Flashcard
+    client:load
+    words={dolchPrePrimer.words}
+    listName={dolchPrePrimer.name}
+  />
+
+  <section class="mt-10">
+    <h2 class="text-xl font-bold text-gray-800 mb-4">Browse by Grade Level</h2>
+    <ul class="flex flex-wrap gap-3">
+      <li>
+        <a
+          href="/kindergarten-sight-words"
+          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+        >
+          Kindergarten Sight Words
+        </a>
+      </li>
+      <li>
+        <a
+          href="/1st-grade-sight-words"
+          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+        >
+          1st Grade Sight Words
+        </a>
+      </li>
+      <li>
+        <a
+          href="/2nd-grade-sight-words"
+          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+        >
+          2nd Grade Sight Words
+        </a>
+      </li>
+    </ul>
+  </section>
+
+  <section class="mt-10">
+    <h2 class="text-xl font-bold text-gray-800 mb-4">Dolch Sight Words</h2>
+    <ul class="flex flex-wrap gap-3">
+      <li>
+        <a
+          href="/dolch-pre-primer"
+          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+        >
+          Dolch Pre-Primer ({dolchPrePrimer.wordCount} words)
+        </a>
+      </li>
+      <li>
+        <a
+          href="/dolch-primer"
+          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+        >
+          Dolch Primer ({dolchPrimer.wordCount} words)
+        </a>
+      </li>
+      <li>
+        <a
+          href="/dolch-sight-words"
+          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+        >
+          All Dolch Sight Words
+        </a>
+      </li>
+    </ul>
+  </section>
+
+  <section class="mt-10">
+    <h2 class="text-xl font-bold text-gray-800 mb-4">Fry Sight Words</h2>
+    <ul class="flex flex-wrap gap-3">
+      <li>
+        <a
+          href="/fry-1-100"
+          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+        >
+          Fry Words 1–100 ({fry1100.wordCount} words)
+        </a>
+      </li>
+      <li>
+        <a
+          href="/fry-sight-words"
+          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+        >
+          All Fry Sight Words
+        </a>
+      </li>
+    </ul>
+  </section>
+
+  <section class="mt-10">
+    <h2 class="text-xl font-bold text-gray-800 mb-3">
+      How to use these flashcards
+    </h2>
+    <p class="text-gray-600 leading-relaxed">
+      Tap the speaker icon to hear the word, then use Next and Previous to move
+      through the list. Hit Shuffle any time to mix things up. Five minutes a
+      day is enough — consistency matters more than long sessions.
+    </p>
+  </section>
+
+  <FAQ faqs={faqs} />
+
+  <RelatedPages currentSlug="home" />
+</BaseLayout>

--- a/src/pages/what-are-sight-words.astro
+++ b/src/pages/what-are-sight-words.astro
@@ -1,0 +1,126 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import FAQ from "../components/FAQ.astro";
+import RelatedPages from "../components/RelatedPages.astro";
+
+const faqs = [
+  {
+    question: "Are sight words the same as high frequency words?",
+    answer:
+      "They are often used interchangeably, but there is a subtle difference. High frequency words are simply words that appear most often in written text. Sight words are words that children are taught to recognize on sight — many of which are high frequency words, but not all sight words are high frequency words.",
+  },
+  {
+    question: "When should children start learning sight words?",
+    answer:
+      "Most children begin learning sight words in pre-kindergarten or kindergarten, typically around age 4 or 5. Starting with a small set of 10 to 20 words and building gradually is more effective than trying to learn a large list all at once.",
+  },
+  {
+    question: "How long does it take to learn sight words?",
+    answer:
+      "With regular practice of 5 to 10 minutes per day, most children can learn 20 new sight words per month. Consistency matters more than the length of each session.",
+  },
+  {
+    question: "What is the best way to practice sight words at home?",
+    answer:
+      "Flashcards are one of the most effective tools because they build instant recognition through repetition. Mix up the order frequently so children learn the words rather than memorizing a sequence. Reading books that use high frequency words reinforces recognition in context.",
+  },
+];
+---
+
+<BaseLayout
+  title="What Are Sight Words? A Guide for Parents"
+  description="Learn what sight words are, why they matter, and how to help your child learn them at home with free flashcards and printable lists."
+  canonicalUrl="https://placeholder.com/what-are-sight-words"
+>
+  <h1 class="text-3xl font-bold text-gray-900 mb-6">What Are Sight Words?</h1>
+
+  <div class="prose prose-gray max-w-none space-y-5 text-gray-600 leading-relaxed">
+    <p>
+      Sight words are common words that children learn to recognize
+      automatically — at a glance, without sounding them out letter by letter.
+      Words like <em>the</em>, <em>said</em>, <em>was</em>, and <em>they</em>
+      show up so often in books that struggling to decode them slows a child
+      down on every page. When those words become instant, reading gets easier
+      and more enjoyable.
+    </p>
+
+    <p>
+      The ability to read sight words fluently frees up a child's mental energy
+      for the harder work of understanding a story and figuring out unfamiliar
+      words. Research consistently shows that automatic word recognition is one
+      of the strongest predictors of overall reading ability. In other words,
+      time spent on sight words pays off far beyond the list itself.
+    </p>
+
+    <p>
+      Sight words are different from phonics. Phonics teaches children rules for
+      sounding out words — blending letters and patterns together. Many sight
+      words don't follow those rules neatly. <em>Said</em> doesn't sound the way
+      it looks. <em>The</em> can't be decoded without already knowing it. That's
+      why they're taught separately, through recognition and repetition rather
+      than decoding strategies.
+    </p>
+
+    <p>
+      The two most widely used sight word lists are the <strong>Dolch list</strong>
+      and the <strong>Fry list</strong>. The Dolch list, compiled in 1948 by
+      Edward Dolch, contains 220 words organized by grade level from pre-primer
+      through 3rd grade. The Fry list, developed by Edward Fry, ranks 1,000
+      words by how frequently they appear in reading materials. Both lists
+      overlap significantly, and both are used in schools across the country.
+    </p>
+  </div>
+
+  <section class="mt-10">
+    <h2 class="text-xl font-bold text-gray-800 mb-5">
+      How to teach sight words at home
+    </h2>
+    <div class="space-y-5 text-gray-600 leading-relaxed">
+      <p>
+        Start small. Pick 5 to 10 words at a time and practice them until your
+        child knows them cold before adding more. Trying to tackle a full list
+        of 40 words at once leads to frustration. Small wins build confidence
+        and make the next batch easier.
+      </p>
+
+      <p>
+        Use flashcards daily, but keep sessions short. Five to ten minutes is
+        enough. The key is showing up every day rather than doing one long
+        session on the weekend. Quick, repeated exposure is what turns a
+        unfamiliar word into an automatic one.
+      </p>
+
+      <p>
+        Mix up the order regularly. When words are always practiced in the same
+        sequence, children can start anticipating the next word instead of
+        actually reading it. Shuffling keeps them honest and builds real
+        recognition.
+      </p>
+
+      <p>
+        Reinforce sight words in books. When your child encounters a word from
+        their list while reading aloud, point it out. Recognizing a word in
+        real text — not just on a flashcard — is what makes the learning stick.
+        Any early reader from the library will be full of the words they're
+        practicing.
+      </p>
+    </div>
+  </section>
+
+  <FAQ faqs={faqs} />
+
+  <section class="mt-10 pt-8 border-t border-gray-200">
+    <p class="text-gray-700">
+      Ready to start practicing?{" "}
+      <a
+        href="/"
+        class="text-blue-700 font-semibold hover:underline"
+      >
+        Practice sight words now with our free flashcards
+      </a>{" "}
+      — no sign-up, no app download, works on any phone.
+    </p>
+  </section>
+
+  <RelatedPages currentSlug="what-are-sight-words" />
+</BaseLayout>


### PR DESCRIPTION
Closes #15

- Add dolch-primer and fry-1-100 word lists to words.json
- Replace placeholder index.astro with full homepage
- Create what-are-sight-words.astro with content, FAQ, and CTA

Generated with [Claude Code](https://claude.ai/code)