### PR TITLE
feat: home page redesign — Nunito font, flashcard card UI, dark footer

### DIFF
--- a/src/components/Flashcard.jsx
+++ b/src/components/Flashcard.jsx
@@ -40,30 +40,47 @@ export default function Flashcard({ words, listName }) {
   }, [currentWord]);
 
   return (
-    <div className="flashcard-tool flex flex-col items-center min-h-[70vh] py-6 px-4">
-      {/* Progress */}
-      <p className="text-sm text-gray-500 mb-4 tracking-wide uppercase">
-        {listName} &mdash; Word {index + 1} of {total}
+    <div className="flashcard-tool flex flex-col items-center py-6 px-4" style={{ backgroundColor: '#f0f4f8' }}>
+      {/* List name */}
+      <p className="text-xs text-gray-400 uppercase tracking-widest mb-1 font-semibold">
+        {listName}
       </p>
 
-      {/* Word display */}
-      <div className="flex-1 flex items-center justify-center w-full">
-        <span className="text-7xl sm:text-8xl font-bold text-gray-900 text-center leading-tight break-words">
+      {/* Progress */}
+      <p className="text-sm text-gray-500 mb-4">
+        Word {index + 1} of {total}
+      </p>
+
+      {/* Card */}
+      <div
+        className="relative w-full flex items-center justify-center"
+        style={{
+          backgroundColor: '#ffffff',
+          borderRadius: '16px',
+          boxShadow: '0 4px 24px rgba(0,0,0,0.10)',
+          border: '1.5px solid #e5e7eb',
+          minHeight: '240px',
+        }}
+      >
+        <span
+          className="text-7xl font-extrabold text-center leading-tight break-words px-6 py-8"
+          style={{ color: '#1e293b' }}
+        >
           {currentWord}
         </span>
-      </div>
 
-      {/* Speaker button */}
-      <button
-        onClick={handleSpeak}
-        aria-label={`Speak the word ${currentWord}`}
-        className="mt-6 flex items-center justify-center w-14 h-14 rounded-full bg-blue-100 text-blue-700 hover:bg-blue-200 active:bg-blue-300 transition-colors"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-7 h-7" aria-hidden="true">
-          <path d="M13.5 4.06c0-1.336-1.616-2.005-2.56-1.06l-4.5 4.5H4.508c-1.141 0-2.318.664-2.66 1.905A9.76 9.76 0 0 0 1.5 12c0 .898.121 1.768.35 2.595.341 1.24 1.518 1.905 2.659 1.905h1.93l4.5 4.5c.945.945 2.561.276 2.561-1.06V4.06ZM18.584 5.106a.75.75 0 0 1 1.06 0c3.808 3.807 3.808 9.98 0 13.788a.75.75 0 0 1-1.06-1.06 8.25 8.25 0 0 0 0-11.668.75.75 0 0 1 0-1.06Z" />
-          <path d="M15.932 7.757a.75.75 0 0 1 1.061 0 6 6 0 0 1 0 8.486.75.75 0 0 1-1.06-1.061 4.5 4.5 0 0 0 0-6.364.75.75 0 0 1 0-1.06Z" />
-        </svg>
-      </button>
+        {/* Speaker button — inside card, bottom right */}
+        <button
+          onClick={handleSpeak}
+          aria-label={`Speak the word ${currentWord}`}
+          className="absolute bottom-3 right-3 flex items-center justify-center w-10 h-10 rounded-full bg-blue-50 text-blue-400 hover:bg-blue-100 hover:text-blue-600 active:bg-blue-200 transition-colors"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5" aria-hidden="true">
+            <path d="M13.5 4.06c0-1.336-1.616-2.005-2.56-1.06l-4.5 4.5H4.508c-1.141 0-2.318.664-2.66 1.905A9.76 9.76 0 0 0 1.5 12c0 .898.121 1.768.35 2.595.341 1.24 1.518 1.905 2.659 1.905h1.93l4.5 4.5c.945.945 2.561.276 2.561-1.06V4.06ZM18.584 5.106a.75.75 0 0 1 1.06 0c3.808 3.807 3.808 9.98 0 13.788a.75.75 0 0 1-1.06-1.06 8.25 8.25 0 0 0 0-11.668.75.75 0 0 1 0-1.06Z" />
+            <path d="M15.932 7.757a.75.75 0 0 1 1.061 0 6 6 0 0 1 0 8.486.75.75 0 0 1-1.06-1.061 4.5 4.5 0 0 0 0-6.364.75.75 0 0 1 0-1.06Z" />
+          </svg>
+        </button>
+      </div>
 
       {/* Navigation */}
       <div className="flex items-center gap-4 mt-6 w-full max-w-sm">
@@ -71,7 +88,7 @@ export default function Flashcard({ words, listName }) {
           onClick={goPrev}
           disabled={index === 0}
           aria-label="Previous word"
-          className="flex-1 min-h-[48px] flex items-center justify-center rounded-xl bg-gray-100 text-gray-700 font-semibold text-lg hover:bg-gray-200 active:bg-gray-300 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          className="flex-1 min-h-[48px] flex items-center justify-center rounded-xl bg-gray-100 text-gray-800 font-bold text-lg hover:bg-gray-200 active:bg-gray-300 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
         >
           ← Prev
         </button>
@@ -79,7 +96,8 @@ export default function Flashcard({ words, listName }) {
         <button
           onClick={shuffle}
           aria-label="Shuffle words"
-          className="min-h-[48px] px-4 flex items-center justify-center rounded-xl bg-yellow-100 text-yellow-800 font-semibold hover:bg-yellow-200 active:bg-yellow-300 transition-colors"
+          className="min-h-[48px] px-5 flex items-center justify-center rounded-xl text-white font-bold hover:opacity-90 active:opacity-80 transition-opacity"
+          style={{ backgroundColor: '#F59E0B' }}
         >
           Shuffle
         </button>
@@ -88,7 +106,8 @@ export default function Flashcard({ words, listName }) {
           onClick={goNext}
           disabled={index === total - 1}
           aria-label="Next word"
-          className="flex-1 min-h-[48px] flex items-center justify-center rounded-xl bg-blue-600 text-white font-semibold text-lg hover:bg-blue-700 active:bg-blue-800 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          className="flex-1 min-h-[48px] flex items-center justify-center rounded-xl text-white font-bold text-lg hover:opacity-90 active:opacity-80 disabled:opacity-30 disabled:cursor-not-allowed transition-opacity"
+          style={{ backgroundColor: '#2563EB' }}
         >
           Next →
         </button>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -26,7 +26,14 @@ const navLinks = [
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalUrl} />
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
+
     <style>
+  body {
+    font-family: 'Nunito', sans-serif;
+  }
 @media print {
   header, footer, .ad-slot, .flashcard-tool, .no-print {
     display: none;
@@ -53,7 +60,7 @@ const navLinks = [
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
           <a
             href="/"
-            class="text-xl font-bold text-blue-700 hover:text-blue-800 shrink-0"
+            class="text-xl font-bold text-blue-600 hover:text-blue-700 shrink-0"
           >
             Sight Words
           </a>
@@ -79,17 +86,17 @@ const navLinks = [
       <slot />
     </main>
 
-    <footer class="bg-gray-50 border-t border-gray-200 mt-auto">
-      <div class="max-w-5xl mx-auto px-4 py-6 text-sm text-gray-600">
+    <footer class="mt-auto" style="background-color: #1e293b;">
+      <div class="max-w-5xl mx-auto px-4 py-8 text-sm text-white">
         <div class="flex flex-wrap gap-x-4 gap-y-1 mb-3">
-          <a href="/dolch-sight-words" class="hover:text-blue-700">Dolch Words</a>
-          <a href="/fry-sight-words" class="hover:text-blue-700">Fry Words</a>
-          <a href="/kindergarten-sight-words" class="hover:text-blue-700">Kindergarten</a>
-          <a href="/sight-word-games" class="hover:text-blue-700">Games</a>
-          <a href="/sight-words-printable" class="hover:text-blue-700">Printable</a>
+          <a href="/dolch-sight-words" class="text-white hover:text-blue-300 transition-colors">Dolch Words</a>
+          <a href="/fry-sight-words" class="text-white hover:text-blue-300 transition-colors">Fry Words</a>
+          <a href="/kindergarten-sight-words" class="text-white hover:text-blue-300 transition-colors">Kindergarten</a>
+          <a href="/sight-word-games" class="text-white hover:text-blue-300 transition-colors">Games</a>
+          <a href="/sight-words-printable" class="text-white hover:text-blue-300 transition-colors">Printable</a>
         </div>
-        <p class="text-gray-500">Free to use — no sign-up required.</p>
-        <p class="text-gray-400 mt-1">&copy; {currentYear} Sight Words. All rights reserved.</p>
+        <p class="text-slate-400">Free to use — no sign-up required.</p>
+        <p class="text-slate-500 mt-1">&copy; {currentYear} Sight Words. All rights reserved.</p>
       </div>
     </footer>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -58,7 +58,7 @@ const faqs = [
       <li>
         <a
           href="/kindergarten-sight-words"
-          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+          class="inline-block px-4 py-1.5 rounded-full bg-blue-50 text-blue-600 font-medium hover:bg-blue-100 transition-colors text-sm"
         >
           Kindergarten Sight Words
         </a>
@@ -66,7 +66,7 @@ const faqs = [
       <li>
         <a
           href="/1st-grade-sight-words"
-          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+          class="inline-block px-4 py-1.5 rounded-full bg-blue-50 text-blue-600 font-medium hover:bg-blue-100 transition-colors text-sm"
         >
           1st Grade Sight Words
         </a>
@@ -74,7 +74,7 @@ const faqs = [
       <li>
         <a
           href="/2nd-grade-sight-words"
-          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+          class="inline-block px-4 py-1.5 rounded-full bg-blue-50 text-blue-600 font-medium hover:bg-blue-100 transition-colors text-sm"
         >
           2nd Grade Sight Words
         </a>
@@ -88,7 +88,7 @@ const faqs = [
       <li>
         <a
           href="/dolch-pre-primer"
-          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+          class="inline-block px-4 py-1.5 rounded-full bg-blue-50 text-blue-600 font-medium hover:bg-blue-100 transition-colors text-sm"
         >
           Dolch Pre-Primer ({dolchPrePrimer.wordCount} words)
         </a>
@@ -96,7 +96,7 @@ const faqs = [
       <li>
         <a
           href="/dolch-primer"
-          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+          class="inline-block px-4 py-1.5 rounded-full bg-blue-50 text-blue-600 font-medium hover:bg-blue-100 transition-colors text-sm"
         >
           Dolch Primer ({dolchPrimer.wordCount} words)
         </a>
@@ -104,7 +104,7 @@ const faqs = [
       <li>
         <a
           href="/dolch-sight-words"
-          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+          class="inline-block px-4 py-1.5 rounded-full bg-blue-50 text-blue-600 font-medium hover:bg-blue-100 transition-colors text-sm"
         >
           All Dolch Sight Words
         </a>
@@ -118,7 +118,7 @@ const faqs = [
       <li>
         <a
           href="/fry-1-100"
-          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+          class="inline-block px-4 py-1.5 rounded-full bg-blue-50 text-blue-600 font-medium hover:bg-blue-100 transition-colors text-sm"
         >
           Fry Words 1–100 ({fry1100.wordCount} words)
         </a>
@@ -126,7 +126,7 @@ const faqs = [
       <li>
         <a
           href="/fry-sight-words"
-          class="inline-block px-4 py-2 rounded-lg bg-blue-50 text-blue-700 font-medium hover:bg-blue-100 transition-colors text-sm"
+          class="inline-block px-4 py-1.5 rounded-full bg-blue-50 text-blue-600 font-medium hover:bg-blue-100 transition-colors text-sm"
         >
           All Fry Sight Words
         </a>


### PR DESCRIPTION
Redesigns visual styling across the site for a clean, warm, and approachable look.

- Add Nunito Google Font as the site default
- Navigation: site name in #2563EB blue
- Footer: dark #1e293b background with white text
- Flashcard: physical card design with shadow, border, speaker button inside card, updated button colors
- Homepage pills: rounded-full chip style in blue

Closes #17

Generated with [Claude Code](https://claude.ai/code)